### PR TITLE
runtime: adjust mutex profile samples at recording time

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -432,8 +432,8 @@ func saveblockevent(cycles, rate int64, skip int, which bucketType) {
 		b.bp().count += float64(rate) / float64(cycles)
 		b.bp().cycles += rate
 	} else {
-		b.bp().count++
-		b.bp().cycles += cycles
+		b.bp().count += float64(rate)
+		b.bp().cycles += rate * cycles
 	}
 	unlock(&proflock)
 }

--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -907,8 +907,7 @@ func writeProfileInternal(w io.Writer, debug int, name string, runtimeProfile fu
 }
 
 func scaleMutexProfile(cnt int64, ns float64) (int64, float64) {
-	period := runtime.SetMutexProfileFraction(-1)
-	return cnt * int64(period), ns * float64(period)
+	return cnt, ns
 }
 
 func runtime_cyclesPerSecond() int64


### PR DESCRIPTION
Previously, the contentions and delays in the mutex profile were
adjusted according to the sampling probability at the time when the
profile is reported, based on the most recently configured sampling
rate. However, this makes the profile inaccurate if the mutex profile
fraction is changed at runtime and the profile contains samples recorded
with different rates. As a special case, setting the mutex profile
fraction to 0 would lead to empty mutex profiles being reported.

Instead, adjust the contention count and delay when each sample is
recorded. This eliminates the problem and is consistent with how the
block profiler does it.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
